### PR TITLE
Use paimon-shaded-guava instead of directly using guava

### DIFF
--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
@@ -26,12 +26,12 @@ import io.trino.spi.transaction.IsolationLevel;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static java.util.Objects.requireNonNull;
 import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
 import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
+import static org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.paimon.trino.TrinoTableHandle.SCAN_SNAPSHOT;
 import static org.apache.paimon.trino.TrinoTableHandle.SCAN_TIMESTAMP;
 

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoMetadataBase.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoMetadataBase.java
@@ -57,11 +57,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Trino {@link ConnectorMetadata}. */
 public abstract class TrinoMetadataBase implements ConnectorMetadata {

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoPageSourceBase.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoPageSourceBase.java
@@ -54,7 +54,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -71,6 +70,7 @@ import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
+import static org.apache.paimon.utils.Preconditions.checkArgument;
 
 /** Trino {@link ConnectorPageSource}. */
 public abstract class TrinoPageSourceBase implements ConnectorPageSource {
@@ -193,7 +193,7 @@ public abstract class TrinoPageSourceBase implements ConnectorPageSource {
         } else if (javaType == Slice.class) {
             writeSlice(output, type, value);
         } else if (javaType == LongTimestampWithTimeZone.class) {
-            verify(type.equals(TIMESTAMP_TZ_MILLIS));
+            checkArgument(type.equals(TIMESTAMP_TZ_MILLIS));
             Timestamp timestamp = (org.apache.paimon.data.Timestamp) value;
             type.writeObject(
                     output, fromEpochMillisAndFraction(timestamp.getMillisecond(), 0, UTC_KEY));

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableOptions.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableOptions.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.trino;
 
-import com.google.common.collect.ImmutableList;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
 

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoColumnHandle.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoColumnHandle.java
@@ -18,9 +18,9 @@
 
 package org.apache.paimon.trino;
 
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.types.DataTypes;
 
-import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoConnectorFactory.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoConnectorFactory.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.trino;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.TestingConnectorContext;

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoDistributedQuery.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoDistributedQuery.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.trino;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import io.trino.testing.AbstractDistributedEngineOnlyQueries;
 import io.trino.testing.QueryRunner;
 import org.testng.SkipException;

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoFilterConverter.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoFilterConverter.java
@@ -21,11 +21,11 @@ package org.apache.paimon.trino;
 import org.apache.paimon.data.BinaryString;
 import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.predicate.PredicateBuilder;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.RowType;
 
-import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoPlugin.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoPlugin.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.trino;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import io.trino.spi.Plugin;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
@@ -29,7 +30,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.UUID;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.apache.paimon.shade.guava30.com.google.common.collect.Iterables.getOnlyElement;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link TrinoPlugin}. */

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TrinoQueryRunner.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TrinoQueryRunner.java
@@ -18,7 +18,8 @@
 
 package org.apache.paimon.trino;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableMap;
+
 import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -171,6 +171,11 @@ This file is based on the checkstyle file of Apache Beam.
 
 		-->
 
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.google.common"/>
+			<message key="import.illegal" value="{0}; Use paimon-shaded-guava instead."/>
+		</module>
+
 		<module name="RedundantImport">
 			<!-- Checks for redundant import statements. -->
 			<property name="severity" value="error"/>


### PR DESCRIPTION
Paimon provides paimon-shaded-guava to avoid class conflicts. We should enforce the developers to use this shaded guava.