### PR TITLE
Fixed the problem of abnormality when using TIMESTAMP_LTZ(3) field as filter condition

### DIFF
--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoFilterConverter.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoFilterConverter.java
@@ -234,6 +234,9 @@ public class TrinoFilterConverter {
         }
 
         if (type.equals(TIMESTAMP_TZ_MILLIS)) {
+            if (trinoNativeValue instanceof Long) {
+                return trinoNativeValue;
+            }
             return Timestamp.fromEpochMillis(
                     ((LongTimestampWithTimeZone) trinoNativeValue).getEpochMillis());
         }


### PR DESCRIPTION
Fixed the problem of abnormality when using TIMESTAMP_LTZ(3) field as filter condition

<img width="1317" alt="image" src="https://github.com/apache/incubator-paimon-trino/assets/34335395/c699babe-009f-45fd-b179-c4371f591ac6">


