### PR TITLE
Fix the problem of query failure for timestamp with timezone type field

### DIFF
--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoPageSourceBase.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoPageSourceBase.java
@@ -57,6 +57,7 @@ import java.util.List;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.Decimals.encodeShortScaledValue;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -183,6 +184,10 @@ public abstract class TrinoPageSourceBase implements ConnectorPageSource {
                         ((Timestamp) value).getMillisecond() * MICROSECONDS_PER_MILLISECOND);
             } else if (type.equals(TIMESTAMP_MICROS)) {
                 type.writeLong(output, ((Timestamp) value).toMicros());
+            } else if (type.equals(TIMESTAMP_TZ_MILLIS)) {
+                type.writeLong(
+                        output,
+                        packDateTimeWithZone(((Timestamp) value).getMillisecond(), UTC_KEY));
             } else if (type.equals(TIME_MICROS)) {
                 type.writeLong(output, (int) value * MICROSECONDS_PER_MILLISECOND);
             } else {

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
@@ -169,7 +169,12 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
                                     new DataField(0, "i", new IntType()),
                                     new DataField(1, "createdtime", new TimestampType(0)),
                                     new DataField(2, "updatedtime", new TimestampType(3)),
-                                    new DataField(3, "microtime", new TimestampType(6))));
+                                    new DataField(3, "microtime", new TimestampType(6)),
+                                    new DataField(
+                                            4,
+                                            "localzonedtime",
+                                            new org.apache.paimon.types.LocalZonedTimestampType(
+                                                    3))));
             new SchemaManager(LocalFileIO.create(), tablePath6)
                     .createTable(
                             new Schema(
@@ -186,7 +191,8 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
                             1,
                             Timestamp.fromMicros(1694505288000000L),
                             Timestamp.fromMicros(1694505288001000L),
-                            Timestamp.fromMicros(1694505288001001L)));
+                            Timestamp.fromMicros(1694505288001001L),
+                            Timestamp.fromMicros(1694505288002001L)));
             commit.commit(0, writer.prepareCommit(true, 0));
         }
 
@@ -446,9 +452,15 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
 
     @Test
     public void testTimestamp0AndTimestamp3() {
-        assertThat(sql("SELECT * FROM paimon.default.t99"))
+        assertThat(sql("SELECT i, createdtime, updatedtime, microtime FROM paimon.default.t99"))
                 .isEqualTo(
                         "[[1, 2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001]]");
+    }
+
+    @Test
+    public void testTimestampWithTimeZone() {
+        assertThat(sql("SELECT localzonedtime FROM paimon.default.t99"))
+                .isEqualTo("[[2023-09-12T07:54:48.002Z[UTC]]]");
     }
 
     private String sql(String sql) {


### PR DESCRIPTION
Fixed the problem of abnormality  when using TIMESTAMP_LTZ(3) field as SELECT field
<img width="909" alt="企业微信截图_16485968-3fef-43da-b7b2-bf52fdc72cd7" src="https://github.com/apache/incubator-paimon-trino/assets/34335395/58672a78-7102-4626-8aea-a1317dfdf444">
<img width="1145" alt="企业微信截图_499e2fcc-4675-4ee9-b85d-326ad187d686" src="https://github.com/apache/incubator-paimon-trino/assets/34335395/c7b0345b-9aff-41ec-9afe-420ab21dcc25">
