### PR TITLE
Add split weight

### DIFF
--- a/paimon-trino-358/src/main/java/org/apache/paimon/trino/TrinoSplit.java
+++ b/paimon-trino-358/src/main/java/org/apache/paimon/trino/TrinoSplit.java
@@ -23,7 +23,6 @@ import org.apache.paimon.table.source.Split;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.HostAddress;
-import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.Collections;
@@ -34,19 +33,13 @@ public class TrinoSplit implements ConnectorSplit {
 
     private final String splitSerialized;
 
-    private final SplitWeight splitWeight;
-
     @JsonCreator
-    public TrinoSplit(
-            @JsonProperty("splitSerialized") String splitSerialized,
-            @JsonProperty("splitWeight") SplitWeight splitWeight) {
+    public TrinoSplit(@JsonProperty("splitSerialized") String splitSerialized) {
         this.splitSerialized = splitSerialized;
-        this.splitWeight = splitWeight;
     }
 
     public static TrinoSplit fromSplit(Split split, double weight) {
-        return new TrinoSplit(
-                EncodingUtils.encodeObjectToString(split), SplitWeight.fromProportion(weight));
+        return new TrinoSplit(EncodingUtils.encodeObjectToString(split));
     }
 
     public Split decodeSplit() {
@@ -71,10 +64,5 @@ public class TrinoSplit implements ConnectorSplit {
     @Override
     public Object getInfo() {
         return Collections.emptyMap();
-    }
-
-    @Override
-    public SplitWeight getSplitWeight() {
-        return splitWeight;
     }
 }

--- a/paimon-trino-358/src/main/java/org/apache/paimon/trino/TrinoSplit.java
+++ b/paimon-trino-358/src/main/java/org/apache/paimon/trino/TrinoSplit.java
@@ -36,8 +36,8 @@ public class TrinoSplit implements ConnectorSplit {
     @JsonCreator
     public TrinoSplit(
             @JsonProperty("splitSerialized") String splitSerialized,
-            // weight is not required,
-            // it's just to align the constructor parameters with other versions.
+            // weight is not required, it's just to align the constructor parameters with other
+            // versions.
             @JsonProperty("weight") Double weight) {
         this.splitSerialized = splitSerialized;
     }

--- a/paimon-trino-358/src/main/java/org/apache/paimon/trino/TrinoSplit.java
+++ b/paimon-trino-358/src/main/java/org/apache/paimon/trino/TrinoSplit.java
@@ -34,12 +34,16 @@ public class TrinoSplit implements ConnectorSplit {
     private final String splitSerialized;
 
     @JsonCreator
-    public TrinoSplit(@JsonProperty("splitSerialized") String splitSerialized) {
+    public TrinoSplit(
+            @JsonProperty("splitSerialized") String splitSerialized,
+            // weight is not required,
+            // it's just to align the constructor parameters with other versions.
+            @JsonProperty("weight") Double weight) {
         this.splitSerialized = splitSerialized;
     }
 
-    public static TrinoSplit fromSplit(Split split, double weight) {
-        return new TrinoSplit(EncodingUtils.encodeObjectToString(split));
+    public static TrinoSplit fromSplit(Split split, Double weight) {
+        return new TrinoSplit(EncodingUtils.encodeObjectToString(split), weight);
     }
 
     public Split decodeSplit() {

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
@@ -23,17 +23,12 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static io.trino.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static java.util.Objects.requireNonNull;
-import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
-import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
 import static org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList.toImmutableList;
-import static org.apache.paimon.trino.TrinoTableHandle.SCAN_SNAPSHOT;
-import static org.apache.paimon.trino.TrinoTableHandle.SCAN_TIMESTAMP;
 
 /** Trino {@link Connector}. */
 public class TrinoConnector implements Connector {
@@ -41,6 +36,7 @@ public class TrinoConnector implements Connector {
     private final TrinoSplitManagerBase trinoSplitManager;
     private final TrinoPageSourceProvider trinoPageSourceProvider;
     private final List<PropertyMetadata<?>> tableProperties;
+    private final List<PropertyMetadata<?>> sessionProperties;
 
     public TrinoConnector(
             TrinoMetadataBase trinoMetadata,
@@ -52,6 +48,7 @@ public class TrinoConnector implements Connector {
                 requireNonNull(trinoPageSourceProvider, "jmxRecordSetProvider is null");
         tableProperties =
                 new TrinoTableOptions().getTableProperties().stream().collect(toImmutableList());
+        sessionProperties = new TrinoSessionProperties().getSessionProperties();
     }
 
     @Override
@@ -78,11 +75,7 @@ public class TrinoConnector implements Connector {
 
     @Override
     public List<PropertyMetadata<?>> getSessionProperties() {
-        return Arrays.asList(
-                PropertyMetadata.longProperty(
-                        SCAN_TIMESTAMP, SCAN_TIMESTAMP_MILLIS.description().toString(), null, true),
-                PropertyMetadata.longProperty(
-                        SCAN_SNAPSHOT, SCAN_SNAPSHOT_ID.description().toString(), null, true));
+        return sessionProperties;
     }
 
     @Override

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoSessionProperties.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoSessionProperties.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino;
+
+import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
+
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.doubleProperty;
+import static io.trino.spi.session.PropertyMetadata.longProperty;
+import static org.apache.paimon.CoreOptions.SCAN_SNAPSHOT_ID;
+import static org.apache.paimon.CoreOptions.SCAN_TIMESTAMP_MILLIS;
+
+/** Trino session properties. */
+public class TrinoSessionProperties {
+
+    public static final String SCAN_TIMESTAMP = "scan_timestamp_millis";
+    public static final String SCAN_SNAPSHOT = "scan_snapshot_id";
+    public static final String MINIMUM_SPLIT_WEIGHT = "minimum_split_weight";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    public TrinoSessionProperties() {
+        sessionProperties =
+                ImmutableList.<PropertyMetadata<?>>builder()
+                        .add(
+                                longProperty(
+                                        SCAN_TIMESTAMP,
+                                        SCAN_TIMESTAMP_MILLIS.description().toString(),
+                                        null,
+                                        true))
+                        .add(
+                                longProperty(
+                                        SCAN_SNAPSHOT,
+                                        SCAN_SNAPSHOT_ID.description().toString(),
+                                        null,
+                                        true))
+                        .add(
+                                doubleProperty(
+                                        MINIMUM_SPLIT_WEIGHT, "Minimum split weight", 0.05, false))
+                        .build();
+    }
+
+    public List<PropertyMetadata<?>> getSessionProperties() {
+        return sessionProperties;
+    }
+
+    public static Long getScanTimestampMillis(ConnectorSession session) {
+        return session.getProperty(SCAN_TIMESTAMP, Long.class);
+    }
+
+    public static Long getScanSnapshotId(ConnectorSession session) {
+        return session.getProperty(SCAN_SNAPSHOT, Long.class);
+    }
+
+    public static Double getMinimumSplitWeight(ConnectorSession session) {
+        return session.getProperty(MINIMUM_SPLIT_WEIGHT, Double.class);
+    }
+}

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoSplit.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoSplit.java
@@ -34,19 +34,18 @@ public class TrinoSplit implements ConnectorSplit {
 
     private final String splitSerialized;
 
-    private final SplitWeight splitWeight;
+    private final Double weight;
 
     @JsonCreator
     public TrinoSplit(
             @JsonProperty("splitSerialized") String splitSerialized,
-            @JsonProperty("splitWeight") SplitWeight splitWeight) {
+            @JsonProperty("weight") Double weight) {
         this.splitSerialized = splitSerialized;
-        this.splitWeight = splitWeight;
+        this.weight = weight;
     }
 
-    public static TrinoSplit fromSplit(Split split, double weight) {
-        return new TrinoSplit(
-                EncodingUtils.encodeObjectToString(split), SplitWeight.fromProportion(weight));
+    public static TrinoSplit fromSplit(Split split, Double weight) {
+        return new TrinoSplit(EncodingUtils.encodeObjectToString(split), weight);
     }
 
     public Split decodeSplit() {
@@ -56,6 +55,11 @@ public class TrinoSplit implements ConnectorSplit {
     @JsonProperty
     public String getSplitSerialized() {
         return splitSerialized;
+    }
+
+    @JsonProperty
+    public Double getWeight() {
+        return weight;
     }
 
     @Override
@@ -75,6 +79,6 @@ public class TrinoSplit implements ConnectorSplit {
 
     @Override
     public SplitWeight getSplitWeight() {
-        return splitWeight;
+        return SplitWeight.fromProportion(weight);
     }
 }

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoSplitManagerBase.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoSplitManagerBase.java
@@ -30,8 +30,6 @@ import io.trino.spi.connector.ConnectorTableHandle;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.paimon.trino.TrinoTableOptions.getMinimumSplitWeight;
-
 /** Trino {@link ConnectorSplitManager}. */
 public abstract class TrinoSplitManagerBase implements ConnectorSplitManager {
 
@@ -50,7 +48,7 @@ public abstract class TrinoSplitManagerBase implements ConnectorSplitManager {
 
         @SuppressWarnings("OptionalGetWithoutIsPresent")
         long maxRowCount = splits.stream().mapToLong(Split::rowCount).max().getAsLong();
-        double minimumSplitWeight = getMinimumSplitWeight(session);
+        double minimumSplitWeight = TrinoSessionProperties.getMinimumSplitWeight(session);
         return new TrinoSplitSource(
                 splits.stream()
                         .map(

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableHandle.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableHandle.java
@@ -46,9 +46,6 @@ import java.util.stream.Collectors;
 /** Trino {@link ConnectorTableHandle}. */
 public final class TrinoTableHandle implements ConnectorTableHandle {
 
-    public static final String SCAN_TIMESTAMP = "scan_timestamp_millis";
-    public static final String SCAN_SNAPSHOT = "scan_snapshot_id";
-
     private final String schemaName;
     private final String tableName;
     private final byte[] serializedTable;
@@ -131,12 +128,12 @@ public final class TrinoTableHandle implements ConnectorTableHandle {
     public Table tableWithDynamicOptions(ConnectorSession session) {
         // see TrinoConnector.getSessionProperties
         Map<String, String> dynamicOptions = new HashMap<>();
-        Long scanTimestampMills = session.getProperty(SCAN_TIMESTAMP, Long.class);
+        Long scanTimestampMills = TrinoSessionProperties.getScanTimestampMillis(session);
         if (scanTimestampMills != null) {
             dynamicOptions.put(
                     CoreOptions.SCAN_TIMESTAMP_MILLIS.key(), scanTimestampMills.toString());
         }
-        Long scanSnapshotId = session.getProperty(SCAN_SNAPSHOT, Long.class);
+        Long scanSnapshotId = TrinoSessionProperties.getScanSnapshotId(session);
         if (scanSnapshotId != null) {
             dynamicOptions.put(CoreOptions.SCAN_SNAPSHOT_ID.key(), scanSnapshotId.toString());
         }

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableOptions.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableOptions.java
@@ -20,12 +20,14 @@ package org.apache.paimon.trino;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
 
 import java.util.List;
 import java.util.Map;
 
+import static io.trino.spi.session.PropertyMetadata.doubleProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -35,6 +37,8 @@ public class TrinoTableOptions {
 
     public static final String PRIMARY_KEY_IDENTIFIER = "primary_key";
     public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
+
+    public static final String MINIMUM_SPLIT_WEIGHT = "minimum_split_weight";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -74,6 +78,8 @@ public class TrinoTableOptions {
                         value -> (List<?>) value,
                         value -> value));
 
+        builder.add(doubleProperty(MINIMUM_SPLIT_WEIGHT, "Minimum split weight", 0.05, false));
+
         tableProperties = builder.build();
     }
 
@@ -91,5 +97,9 @@ public class TrinoTableOptions {
     public static List<String> getPartitionedKeys(Map<String, Object> tableProperties) {
         List<String> partitionedKeys = (List<String>) tableProperties.get(PARTITIONED_BY_PROPERTY);
         return partitionedKeys == null ? ImmutableList.of() : ImmutableList.copyOf(partitionedKeys);
+    }
+
+    public static double getMinimumSplitWeight(ConnectorSession session) {
+        return session.getProperty(MINIMUM_SPLIT_WEIGHT, Double.class);
     }
 }

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableOptions.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoTableOptions.java
@@ -20,14 +20,12 @@ package org.apache.paimon.trino;
 
 import org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList;
 
-import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
 
 import java.util.List;
 import java.util.Map;
 
-import static io.trino.spi.session.PropertyMetadata.doubleProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -37,8 +35,6 @@ public class TrinoTableOptions {
 
     public static final String PRIMARY_KEY_IDENTIFIER = "primary_key";
     public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
-
-    public static final String MINIMUM_SPLIT_WEIGHT = "minimum_split_weight";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -78,8 +74,6 @@ public class TrinoTableOptions {
                         value -> (List<?>) value,
                         value -> value));
 
-        builder.add(doubleProperty(MINIMUM_SPLIT_WEIGHT, "Minimum split weight", 0.05, false));
-
         tableProperties = builder.build();
     }
 
@@ -97,9 +91,5 @@ public class TrinoTableOptions {
     public static List<String> getPartitionedKeys(Map<String, Object> tableProperties) {
         List<String> partitionedKeys = (List<String>) tableProperties.get(PARTITIONED_BY_PROPERTY);
         return partitionedKeys == null ? ImmutableList.of() : ImmutableList.copyOf(partitionedKeys);
-    }
-
-    public static double getMinimumSplitWeight(ConnectorSession session) {
-        return session.getProperty(MINIMUM_SPLIT_WEIGHT, Double.class);
     }
 }

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoSplit.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoSplit.java
@@ -33,7 +33,7 @@ public class TestTrinoSplit {
     @Test
     public void testJsonRoundTrip() throws Exception {
         byte[] serializedTable = TrinoTestUtils.getSerializedTable();
-        TrinoSplit expected = new TrinoSplit(Arrays.toString(serializedTable));
+        TrinoSplit expected = new TrinoSplit(Arrays.toString(serializedTable), 0.1);
         String json = codec.toJson(expected);
         TrinoSplit actual = codec.fromJson(json);
         assertThat(actual.getSplitSerialized()).isEqualTo(expected.getSplitSerialized());


### PR DESCRIPTION
Trino uses SplitWeight to determine the execution cost of each split. With the addition of SplitWeight, Trino can more evenly distribute splits to different nodes.