### PR TITLE
Adapt trino 435 version

### DIFF
--- a/paimon-trino-422/src/main/java/org/apache/paimon/trino/TrinoConnector.java
+++ b/paimon-trino-422/src/main/java/org/apache/paimon/trino/TrinoConnector.java
@@ -37,12 +37,12 @@ public class TrinoConnector extends TrinoConnectorBase {
     @Override
     public ConnectorTransactionHandle beginTransaction(
             IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit) {
-        return super.beginTransaction(isolationLevel, readOnly);
+        return beginTransactionBase(isolationLevel, readOnly);
     }
 
     @Override
     public ConnectorMetadata getMetadata(
             ConnectorSession session, ConnectorTransactionHandle transactionHandle) {
-        return super.getMetadata(transactionHandle);
+        return getMetadataBase(transactionHandle);
     }
 }

--- a/paimon-trino-422/src/main/java/org/apache/paimon/trino/TrinoConnector.java
+++ b/paimon-trino-422/src/main/java/org/apache/paimon/trino/TrinoConnector.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.trino;
 
 import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.transaction.IsolationLevel;
 
@@ -34,12 +36,13 @@ public class TrinoConnector extends TrinoConnectorBase {
 
     @Override
     public ConnectorTransactionHandle beginTransaction(
-            IsolationLevel isolationLevel, boolean readOnly) {
+            IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit) {
         return super.beginTransaction(isolationLevel, readOnly);
     }
 
     @Override
-    public TrinoMetadataBase getMetadata(ConnectorTransactionHandle transactionHandle) {
+    public ConnectorMetadata getMetadata(
+            ConnectorSession session, ConnectorTransactionHandle transactionHandle) {
         return super.getMetadata(transactionHandle);
     }
 }

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
@@ -19,6 +19,8 @@
 package org.apache.paimon.trino;
 
 import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
@@ -59,8 +61,20 @@ public class TrinoConnector implements Connector {
     }
 
     @Override
+    public ConnectorTransactionHandle beginTransaction(
+            IsolationLevel isolationLevel, boolean readOnly, boolean autoCommit) {
+        return beginTransaction(isolationLevel, readOnly);
+    }
+
+    @Override
     public TrinoMetadataBase getMetadata(ConnectorTransactionHandle transactionHandle) {
         return trinoMetadata;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(
+            ConnectorSession session, ConnectorTransactionHandle transactionHandle) {
+        return getMetadata(transactionHandle);
     }
 
     @Override

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnector.java
@@ -35,11 +35,11 @@ public class TrinoConnector extends TrinoConnectorBase {
     @Override
     public ConnectorTransactionHandle beginTransaction(
             IsolationLevel isolationLevel, boolean readOnly) {
-        return super.beginTransaction(isolationLevel, readOnly);
+        return beginTransactionBase(isolationLevel, readOnly);
     }
 
     @Override
     public TrinoMetadataBase getMetadata(ConnectorTransactionHandle transactionHandle) {
-        return super.getMetadata(transactionHandle);
+        return getMetadataBase(transactionHandle);
     }
 }

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnectorBase.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnectorBase.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.trino;
+
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.transaction.IsolationLevel;
+
+import java.util.List;
+
+import static io.trino.spi.transaction.IsolationLevel.READ_COMMITTED;
+import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
+import static java.util.Objects.requireNonNull;
+import static org.apache.paimon.shade.guava30.com.google.common.collect.ImmutableList.toImmutableList;
+
+/** Trino {@link Connector}. */
+public abstract class TrinoConnectorBase implements Connector {
+    private final TrinoMetadataBase trinoMetadata;
+    private final TrinoSplitManagerBase trinoSplitManager;
+    private final TrinoPageSourceProvider trinoPageSourceProvider;
+    private final List<PropertyMetadata<?>> tableProperties;
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    public TrinoConnectorBase(
+            TrinoMetadataBase trinoMetadata,
+            TrinoSplitManagerBase trinoSplitManager,
+            TrinoPageSourceProvider trinoPageSourceProvider) {
+        this.trinoMetadata = requireNonNull(trinoMetadata, "jmxMetadata is null");
+        this.trinoSplitManager = requireNonNull(trinoSplitManager, "jmxSplitManager is null");
+        this.trinoPageSourceProvider =
+                requireNonNull(trinoPageSourceProvider, "jmxRecordSetProvider is null");
+        tableProperties =
+                new TrinoTableOptions().getTableProperties().stream().collect(toImmutableList());
+        sessionProperties = new TrinoSessionProperties().getSessionProperties();
+    }
+
+    public ConnectorTransactionHandle beginTransaction(
+            IsolationLevel isolationLevel, boolean readOnly) {
+        checkConnectorSupports(READ_COMMITTED, isolationLevel);
+        return TrinoTransactionHandle.INSTANCE;
+    }
+
+    public TrinoMetadataBase getMetadata(ConnectorTransactionHandle transactionHandle) {
+        return trinoMetadata;
+    }
+
+    @Override
+    public TrinoSplitManagerBase getSplitManager() {
+        return trinoSplitManager;
+    }
+
+    @Override
+    public TrinoPageSourceProvider getPageSourceProvider() {
+        return trinoPageSourceProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties() {
+        return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties() {
+        return tableProperties;
+    }
+}

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnectorBase.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoConnectorBase.java
@@ -51,13 +51,13 @@ public abstract class TrinoConnectorBase implements Connector {
         sessionProperties = new TrinoSessionProperties().getSessionProperties();
     }
 
-    public ConnectorTransactionHandle beginTransaction(
+    protected ConnectorTransactionHandle beginTransactionBase(
             IsolationLevel isolationLevel, boolean readOnly) {
         checkConnectorSupports(READ_COMMITTED, isolationLevel);
         return TrinoTransactionHandle.INSTANCE;
     }
 
-    public TrinoMetadataBase getMetadata(ConnectorTransactionHandle transactionHandle) {
+    protected TrinoMetadataBase getMetadataBase(ConnectorTransactionHandle transactionHandle) {
         return trinoMetadata;
     }
 


### PR DESCRIPTION
**Purpose**
Linked issue: close https://github.com/apache/incubator-paimon/issues/2514

In some versions higher than 422, the 
```
io.trino.spi.connector.Connector#beginTransaction(io.trino.spi.transaction.IsolationLevel, boolean)
io.trino.spi.connector.Connector#getMetadata(io.trino.spi.connector.ConnectorTransactionHandle)
```
methods have been removed. This will result in paimon-trino-422 being unavailable in some higher versions.

**Test**
I test this in trino 435 cluster