### PR TITLE
Fix can not read row type in trino version > 422

### DIFF
--- a/paimon-trino-358/src/test/java/org/apache/paimon/trino/TestTrino358ITCase.java
+++ b/paimon-trino-358/src/test/java/org/apache/paimon/trino/TestTrino358ITCase.java
@@ -20,8 +20,6 @@ package org.apache.paimon.trino;
 
 import org.testng.annotations.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /** {@link TestTrinoITCase} for Trino 358. */
 public class TestTrino358ITCase extends TestTrinoITCase {
 
@@ -33,14 +31,5 @@ public class TestTrino358ITCase extends TestTrinoITCase {
     @Test
     public void testSetTableProperties() {
         // not supported
-    }
-
-    @Test
-    public void testAllType() {
-        assertThat(sql("SELECT * FROM paimon.default.t99"))
-                .isEqualTo(
-                        "[[true, 1, 1, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, 2023-09-12T07:54:48, "
-                                + "2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, 2023-09-12T07:54:48.002Z[UTC], "
-                                + "0.10000, java.nio.HeapByteBuffer[pos=0 lim=3 cap=3], [1, 1, 1], {1=1}, [1, 1]]]");
     }
 }

--- a/paimon-trino-358/src/test/java/org/apache/paimon/trino/TestTrino358ITCase.java
+++ b/paimon-trino-358/src/test/java/org/apache/paimon/trino/TestTrino358ITCase.java
@@ -20,6 +20,8 @@ package org.apache.paimon.trino;
 
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** {@link TestTrinoITCase} for Trino 358. */
 public class TestTrino358ITCase extends TestTrinoITCase {
 
@@ -31,5 +33,14 @@ public class TestTrino358ITCase extends TestTrinoITCase {
     @Test
     public void testSetTableProperties() {
         // not supported
+    }
+
+    @Test
+    public void testAllType() {
+        assertThat(sql("SELECT * FROM paimon.default.t99"))
+                .isEqualTo(
+                        "[[true, 1, 1, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, 2023-09-12T07:54:48, "
+                                + "2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, 2023-09-12T07:54:48.002Z[UTC], "
+                                + "0.10000, java.nio.HeapByteBuffer[pos=0 lim=3 cap=3], [1, 1, 1], {1=1}, [1, 1]]]");
     }
 }

--- a/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoPageSourceBase.java
+++ b/paimon-trino-common/src/main/java/org/apache/paimon/trino/TrinoPageSourceBase.java
@@ -34,7 +34,6 @@ import io.airlift.slice.Slice;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
-import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
@@ -236,7 +235,9 @@ public abstract class TrinoPageSourceBase implements ConnectorPageSource {
             Timestamp timestamp = (org.apache.paimon.data.Timestamp) value;
             type.writeObject(
                     output, fromEpochMillisAndFraction(timestamp.getMillisecond(), 0, UTC_KEY));
-        } else if (javaType == Block.class) {
+        } else if (type instanceof ArrayType
+                || type instanceof MapType
+                || type instanceof RowType) {
             writeBlock(output, type, logicalType, value);
         } else {
             throw new TrinoException(

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
@@ -30,7 +30,6 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
-import org.apache.paimon.table.sink.DynamicBucketRow;
 import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.InnerTableWrite;
 import org.apache.paimon.types.ArrayType;
@@ -232,6 +231,7 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
                             new Schema(
                                     rowType.getFields(),
                                     List.of(
+                                            "boolean",
                                             "tinyint",
                                             "smallint",
                                             "int",
@@ -263,34 +263,32 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
                                             "timestamp_tz",
                                             "decimal",
                                             "varbinary"),
-                                    Map.of("bucket", "-1"),
+                                    Collections.emptyMap(),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath6);
             InnerTableWrite writer = table.newWrite("user");
             InnerTableCommit commit = table.newCommit("user");
             writer.write(
-                    new DynamicBucketRow(
-                            GenericRow.of(
-                                    true,
-                                    (byte) 1,
-                                    (short) 1,
-                                    1,
-                                    1L,
-                                    1.0f,
-                                    1.0d,
-                                    BinaryString.fromString("char1"),
-                                    BinaryString.fromString("varchar1"),
-                                    0,
-                                    Timestamp.fromMicros(1694505288000000L),
-                                    Timestamp.fromMicros(1694505288001000L),
-                                    Timestamp.fromMicros(1694505288001001L),
-                                    Timestamp.fromMicros(1694505288002001L),
-                                    Decimal.fromUnscaledLong(10000, 10, 5),
-                                    new byte[] {0x01, 0x02, 0x03},
-                                    new GenericArray(new int[] {1, 1, 1}),
-                                    new GenericMap(Map.of(1, 1)),
-                                    GenericRow.of(1, 1)),
-                            0));
+                    GenericRow.of(
+                            true,
+                            (byte) 1,
+                            (short) 1,
+                            1,
+                            1L,
+                            1.0f,
+                            1.0d,
+                            BinaryString.fromString("char1"),
+                            BinaryString.fromString("varchar1"),
+                            0,
+                            Timestamp.fromMicros(1694505288000000L),
+                            Timestamp.fromMicros(1694505288001000L),
+                            Timestamp.fromMicros(1694505288001001L),
+                            Timestamp.fromMicros(1694505288002001L),
+                            Decimal.fromUnscaledLong(10000, 10, 5),
+                            new byte[] {0x01, 0x02, 0x03},
+                            new GenericArray(new int[] {1, 1, 1}),
+                            new GenericMap(Map.of(1, 1)),
+                            GenericRow.of(1, 1)));
             commit.commit(0, writer.prepareCommit(true, 0));
         }
 

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
@@ -571,11 +571,14 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
 
     @Test
     public void testAllType() {
-        assertThat(sql("SELECT * FROM paimon.default.t99"))
+        assertThat(
+                        sql(
+                                "SELECT boolean, tinyint, smallint,int,bigint,float,double,char,varchar, date,timestamp_0, "
+                                        + "timestamp_3, timestamp_6, timestamp_tz, decimal, to_hex(varbinary), array, map, row FROM paimon.default.t99"))
                 .isEqualTo(
                         "[[true, 1, 1, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, "
                                 + "2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, "
-                                + "2023-09-12T07:54:48.002Z[UTC], 0.10000, X'01 02 03', [1, 1, 1], {1=1}, [1, 1]]]");
+                                + "2023-09-12T07:54:48.002Z[UTC], 0.10000, 010203, [1, 1, 1], {1=1}, [1, 1]]]");
     }
 
     @Test

--- a/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
+++ b/paimon-trino-common/src/test/java/org/apache/paimon/trino/TestTrinoITCase.java
@@ -18,6 +18,8 @@
 
 package org.apache.paimon.trino;
 
+import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericMap;
 import org.apache.paimon.data.GenericRow;
@@ -28,6 +30,7 @@ import org.apache.paimon.schema.Schema;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.FileStoreTableFactory;
+import org.apache.paimon.table.sink.DynamicBucketRow;
 import org.apache.paimon.table.sink.InnerTableCommit;
 import org.apache.paimon.table.sink.InnerTableWrite;
 import org.apache.paimon.types.ArrayType;
@@ -39,7 +42,6 @@ import org.apache.paimon.types.IntType;
 import org.apache.paimon.types.MapType;
 import org.apache.paimon.types.RowKind;
 import org.apache.paimon.types.RowType;
-import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.VarCharType;
 
 import io.trino.testing.AbstractTestQueryFramework;
@@ -195,33 +197,100 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
             RowType rowType =
                     new RowType(
                             Arrays.asList(
-                                    new DataField(0, "i", new IntType()),
-                                    new DataField(1, "createdtime", new TimestampType(0)),
-                                    new DataField(2, "updatedtime", new TimestampType(3)),
-                                    new DataField(3, "microtime", new TimestampType(6)),
+                                    new DataField(0, "boolean", DataTypes.BOOLEAN()),
+                                    new DataField(1, "tinyint", DataTypes.TINYINT()),
+                                    new DataField(2, "smallint", DataTypes.SMALLINT()),
+                                    new DataField(3, "int", DataTypes.INT()),
+                                    new DataField(4, "bigint", DataTypes.BIGINT()),
+                                    new DataField(5, "float", DataTypes.FLOAT()),
+                                    new DataField(6, "double", DataTypes.DOUBLE()),
+                                    new DataField(7, "char", DataTypes.CHAR(5)),
+                                    new DataField(8, "varchar", DataTypes.VARCHAR(100)),
+                                    new DataField(9, "date", DataTypes.DATE()),
+                                    new DataField(10, "timestamp_0", DataTypes.TIMESTAMP(0)),
+                                    new DataField(11, "timestamp_3", DataTypes.TIMESTAMP(3)),
+                                    new DataField(12, "timestamp_6", DataTypes.TIMESTAMP(6)),
                                     new DataField(
-                                            4,
-                                            "localzonedtime",
-                                            new org.apache.paimon.types.LocalZonedTimestampType(
-                                                    3))));
+                                            13,
+                                            "timestamp_tz",
+                                            DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)),
+                                    new DataField(14, "decimal", DataTypes.DECIMAL(10, 5)),
+                                    new DataField(15, "varbinary", DataTypes.VARBINARY(10)),
+                                    new DataField(16, "array", DataTypes.ARRAY(DataTypes.INT())),
+                                    new DataField(
+                                            17,
+                                            "map",
+                                            DataTypes.MAP(DataTypes.INT(), DataTypes.INT())),
+                                    new DataField(
+                                            18,
+                                            "row",
+                                            DataTypes.ROW(
+                                                    DataTypes.FIELD(100, "q1", DataTypes.INT()),
+                                                    DataTypes.FIELD(101, "q2", DataTypes.INT())))));
             new SchemaManager(LocalFileIO.create(), tablePath6)
                     .createTable(
                             new Schema(
                                     rowType.getFields(),
-                                    Collections.emptyList(),
-                                    Collections.singletonList("i"),
-                                    new HashMap<>(),
+                                    List.of(
+                                            "tinyint",
+                                            "smallint",
+                                            "int",
+                                            "bigint",
+                                            "float",
+                                            "double",
+                                            "char",
+                                            "varchar",
+                                            "date",
+                                            "timestamp_0",
+                                            "timestamp_3",
+                                            "timestamp_6",
+                                            "timestamp_tz",
+                                            "decimal"),
+                                    List.of(
+                                            "boolean",
+                                            "tinyint",
+                                            "smallint",
+                                            "int",
+                                            "bigint",
+                                            "float",
+                                            "double",
+                                            "char",
+                                            "varchar",
+                                            "date",
+                                            "timestamp_0",
+                                            "timestamp_3",
+                                            "timestamp_6",
+                                            "timestamp_tz",
+                                            "decimal",
+                                            "varbinary"),
+                                    Map.of("bucket", "-1"),
                                     ""));
             FileStoreTable table = FileStoreTableFactory.create(LocalFileIO.create(), tablePath6);
             InnerTableWrite writer = table.newWrite("user");
             InnerTableCommit commit = table.newCommit("user");
             writer.write(
-                    GenericRow.of(
-                            1,
-                            Timestamp.fromMicros(1694505288000000L),
-                            Timestamp.fromMicros(1694505288001000L),
-                            Timestamp.fromMicros(1694505288001001L),
-                            Timestamp.fromMicros(1694505288002001L)));
+                    new DynamicBucketRow(
+                            GenericRow.of(
+                                    true,
+                                    (byte) 1,
+                                    (short) 1,
+                                    1,
+                                    1L,
+                                    1.0f,
+                                    1.0d,
+                                    BinaryString.fromString("char1"),
+                                    BinaryString.fromString("varchar1"),
+                                    0,
+                                    Timestamp.fromMicros(1694505288000000L),
+                                    Timestamp.fromMicros(1694505288001000L),
+                                    Timestamp.fromMicros(1694505288001001L),
+                                    Timestamp.fromMicros(1694505288002001L),
+                                    Decimal.fromUnscaledLong(10000, 10, 5),
+                                    new byte[] {0x01, 0x02, 0x03},
+                                    new GenericArray(new int[] {1, 1, 1}),
+                                    new GenericMap(Map.of(1, 1)),
+                                    GenericRow.of(1, 1)),
+                            0));
             commit.commit(0, writer.prepareCommit(true, 0));
         }
 
@@ -501,16 +570,12 @@ public abstract class TestTrinoITCase extends AbstractTestQueryFramework {
     }
 
     @Test
-    public void testTimestamp0AndTimestamp3() {
-        assertThat(sql("SELECT i, createdtime, updatedtime, microtime FROM paimon.default.t99"))
+    public void testAllType() {
+        assertThat(sql("SELECT * FROM paimon.default.t99"))
                 .isEqualTo(
-                        "[[1, 2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001]]");
-    }
-
-    @Test
-    public void testTimestampWithTimeZone() {
-        assertThat(sql("SELECT localzonedtime FROM paimon.default.t99"))
-                .isEqualTo("[[2023-09-12T07:54:48.002Z[UTC]]]");
+                        "[[true, 1, 1, 1, 1, 1.0, 1.0, char1, varchar1, 1970-01-01, "
+                                + "2023-09-12T07:54:48, 2023-09-12T07:54:48.001, 2023-09-12T07:54:48.001001, "
+                                + "2023-09-12T07:54:48.002Z[UTC], 0.10000, X'01 02 03', [1, 1, 1], {1=1}, [1, 1]]]");
     }
 
     @Test


### PR DESCRIPTION
**Purpose**
Linked issue: close https://github.com/apache/incubator-paimon/issues/2159

The java class of RowType and MapType is not Block in trino version > 422

**Test**
I had test this in trino 435 version. 