### PR TITLE
enable trino-paimon-plugin to print SLF4J logs in trino.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,7 @@ under the License.
     <properties>
         <target.java.version>11</target.java.version>
         <junit5.version>5.8.1</junit5.version>
-        <slf4j.version>1.7.25</slf4j.version>
-        <log4j.version>2.17.1</log4j.version>
+        <slf4j.version>2.0.7</slf4j.version>
         <guava.version>31.1-jre</guava.version>
         <commons-lang3.version>3.3.2</commons-lang3.version>
         <findbugs.version>1.3.9</findbugs.version>
@@ -126,21 +125,9 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This commit enable trino-paimon-plugin to print SLF4J logs in Trino engine.
![image](https://github.com/apache/incubator-paimon-trino/assets/10346310/464527e7-99aa-423e-9f52-7ccd8d94fe99)
