### PR TITLE
Add toolkit as dependency

### DIFF
--- a/paimon-trino-422/pom.xml
+++ b/paimon-trino-422/pom.xml
@@ -51,7 +51,6 @@ under the License.
             <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
             <version>${trino.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/paimon-trino-427/pom.xml
+++ b/paimon-trino-427/pom.xml
@@ -51,7 +51,6 @@ under the License.
             <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
             <version>${trino.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Paimon dv table need trino-toolkit-plugin as a dependency. 
Iceberg also added it.